### PR TITLE
add "sethomepage" action into eosio.system.

### DIFF
--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -40,6 +40,13 @@
         {"name":"bid", "type":"asset"}
       ]
     },{
+      "name": "sethomepage",
+      "base": "",
+      "fields": [
+        {"name":"account",  "type":"account_name"},
+        {"name":"url", "type":"string"}
+      ]
+    },{
       "name": "permission_level_weight",
       "base": "",
       "fields": [
@@ -404,6 +411,12 @@
           {"name":"high_bid", "type":"int64"},
           {"name":"last_bid_time", "type":"uint64"}
        ]
+    }, {
+       "name": "homepage_info",
+       "base": "",
+       "fields": [
+          {"name":"url", "type":"string"}
+       ]
     }
    ],
    "actions": [{
@@ -477,6 +490,10 @@
    },{
       "name": "bidname",
       "type": "bidname",
+      "ricardian_contract": ""
+   },{
+      "name": "sethomepage",
+      "type": "sethomepage",
       "ricardian_contract": ""
    },{
       "name": "unregprod",
@@ -571,6 +588,12 @@
        "index_type": "i64",
        "key_names" : ["newname"],
        "key_types" : ["account_name"]
+    },{
+       "name": "homepages",
+       "type": "homepage_info",
+       "index_type": "i64",
+       "key_names" : [],
+       "key_types" : []
     }
    ],
    "ricardian_clauses": [],

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -134,6 +134,13 @@ namespace eosiosystem {
       }
    }
 
+   void system_contract::sethomepage(account_name account, std::string url){
+      require_auth(account);
+      eosio_assert( url.size()<=256,"url is too long");
+      eosio_assert( url.find("http")==0,"illegal url");
+	  home_page_singletone page(_self,account);
+	  page.set(home_page{url}, account);
+   }
    /**
     *  Called after a new account is created. This code enforces resource-limits rules
     *  for new accounts as well as new account naming conventions.
@@ -188,7 +195,7 @@ EOSIO_ABI( eosiosystem::system_contract,
      // native.hpp (newaccount definition is actually in eosio.system.cpp)
      (newaccount)(updateauth)(deleteauth)(linkauth)(unlinkauth)(canceldelay)(onerror)
      // eosio.system.cpp
-     (setram)(setparams)(setpriv)(rmvproducer)(bidname)
+     (setram)(setparams)(setpriv)(rmvproducer)(bidname)(sethomepage)
      // delegate_bandwidth.cpp
      (buyrambytes)(buyram)(sellram)(delegatebw)(undelegatebw)(refund)
      // voting.cpp

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -125,6 +125,14 @@ namespace eosiosystem {
    static constexpr uint32_t     seconds_per_day = 24 * 3600;
    static constexpr uint64_t     system_token_symbol = CORE_SYMBOL;
 
+   /*For accounts to store their front page url
+	by doing this accounts can easily guide users to their dapp*/
+	struct home_page{
+	   std::string url;
+	   EOSLIB_SERIALIZE(home_page,(url))
+	};
+	typedef eosio::singleton<N(homepages),home_page> home_page_singletone;
+
    class system_contract : public native {
       private:
          voters_table           _voters;
@@ -214,6 +222,9 @@ namespace eosiosystem {
          void rmvproducer( account_name producer );
 
          void bidname( account_name bidder, account_name newname, asset bid );
+
+         void sethomepage(account_name account,std::string url);
+		 inline std::string gethomepage(account_name account) const;
       private:
          void update_elected_producers( block_timestamp timestamp );
 
@@ -231,5 +242,14 @@ namespace eosiosystem {
          // defined in voting.cpp
          void propagate_weight_change( const voter_info& voter );
    };
+
+   std::string system_contract::gethomepage(account_name account)const{
+      home_page_singletone page(_self,account);
+      if(page.exists()){
+         return page.get().url;
+      }else{
+         return "";
+      }
+   }
 
 } /// eosiosystem


### PR DESCRIPTION
sometimes users maybe interested in some accounts,but don't know what that account is doing,
so we add this action let dapp set their homepage.
Let dapps can explain themselves and guide users to use them.

actually we have 2 options to achieve this:
op1.modify "get_account" related structs,interfaces,so this info can be seen by "get_account".
    but this needs modify database schemes and may cause complicated confluences to BPs.
op2.add multi_index to store and query,it's easy and have no confluence to current struct.
    shortage is users/dapp may don't know this new action, it needs learning.
For safety and easy use, I choose op2.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

add "sethomepage" action into eosio.system.

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

use singleton "homepages" to store the url, it'll be different for each account because "scope" is account name.
dapp can call eosio.system->sethomepage to set the home page url.
users can use get table to fetch the url.
also added inline action gethomepage for easy use in contracts.
No influences to any current behavior of BOS.

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


No influence to validation of blocks or consensus.

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

api change:
1. added action "sethomepage" in eosio.system.
2. added inline action "gethomepage" in eosio.system, this's not visible to users. only visible to contracts.

<!-- List all the information that needs to be added to the documentation after merge. -->
