### PR TITLE
modify cleos : add "homepage" for "get account", and add "set persona…"

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1806,6 +1806,28 @@ read_only::get_account_results read_only::get_account( const get_account_params&
          }
       }
    }
+
+   //get homepage
+   if(nullptr != db.db().find<account_object,by_name>(N(personal.bos))){
+      const auto& personal_account = db.db().get<account_object,by_name>( N(personal.bos) );
+      abi_def abi_personal;
+      if( abi_serializer::to_abi(personal_account.abi, abi_personal) ) {
+         abi_serializer abis_personal( abi_personal, abi_serializer_max_time );
+         const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( N(personal.bos), params.account_name, N(personaldata) ));
+            if (t_id != nullptr) {
+            const auto &idx = d.get_index<key_value_index, by_scope_primary>();
+
+            name key_name{"homepage"};
+            auto it = idx.find(boost::make_tuple( t_id->id, key_name.value ));
+            if ( it != idx.end() ) {
+               vector<char> data;
+               copy_inline_row(*it, data);
+               variant raw_data= abis_personal.binary_to_variant( "personal", data, abi_serializer_max_time, shorten_abi_errors );
+               result.homepage=raw_data["value"].as_string();
+            }
+         }
+      }
+   }
    return result;
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -138,6 +138,7 @@ public:
       fc::variant                self_delegated_bandwidth;
       fc::variant                refund_request;
       fc::variant                voter_info;
+      string                     homepage;
    };
 
    struct get_account_params {
@@ -734,7 +735,7 @@ FC_REFLECT( eosio::chain_apis::read_only::get_scheduled_transactions_result, (tr
 FC_REFLECT( eosio::chain_apis::read_only::get_account_results,
             (account_name)(head_block_num)(head_block_time)(privileged)(last_code_update)(created)
             (core_liquid_balance)(ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)
-            (total_resources)(self_delegated_bandwidth)(refund_request)(voter_info) )
+            (total_resources)(self_delegated_bandwidth)(refund_request)(voter_info)(homepage) )
 FC_REFLECT( eosio::chain_apis::read_only::get_code_results, (account_name)(code_hash)(wast)(wasm)(abi) )
 FC_REFLECT( eosio::chain_apis::read_only::get_code_hash_results, (account_name)(code_hash) )
 FC_REFLECT( eosio::chain_apis::read_only::get_abi_results, (account_name)(abi) )


### PR DESCRIPTION
in "bos.contracts",new contract "personal.bos" was added to let user save personal data,ex. homepage.
To let user use it easier, modify "cleos" adding below functions:

1. in "cleos get account xxx",if this account has table "personaldata" and has key "homepage",display its value in result.
2. add new sub command: "cleos set personal xx1 xx2 xx3" for easy set personal data,where
     xx1 is account to operate
     xx2 is key
     xx3 is value
     it's implimented by calling "personal.bos"->setpersonal

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->
modify cleos : add "homepage" for "get account", and add "set persona…"
## Change Description

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
1. in "cleos get account xxx",if this account has table "personaldata" and has key "homepage",display its value in result.
2. add new sub command: "cleos set personal xx1 xx2 xx3" for easy set personal data,where
     xx1 is account to operate
     xx2 is key
     xx3 is value
reference change : https://github.com/boscore/bos.contracts/pull/66
## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->
none

## API Changes

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
add new sub command: "cleos set personal xx1 xx2 xx3" for easy set personal data,where
     xx1 is account to operate
     xx2 is key
     xx3 is value

## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
