### PR TITLE
feature/dpos-pbft-bos-upgrade bugfix and snapshot support

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2335,8 +2335,10 @@ block_id_type controller::last_stable_checkpoint_block_id() const {
 
     if( block_header::num_from_id(tapos_block_summary.block_id) == lscb_num )
         return tapos_block_summary.block_id;
-    if (lscb_num == 0) return block_id_type{};
-    return fetch_block_by_number(lscb_num)->id();
+
+    auto b = fetch_block_by_number(lscb_num);
+    if (b) return b->id();
+    return block_id_type{};
 }
 
 

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -78,10 +78,20 @@ namespace eosio { namespace chain {
                  vector<char> tmp = data;
                  tmp.insert(tmp.begin(), {0,0,0,0});
                  fc::datastream<const char*> tmp_ds(tmp.data(), tmp.size());
-                 block_state s;
-                 fc::raw::unpack( tmp_ds, s );
-                 //prepend 4bytes for pbft_stable_checkpoint_blocknum and append 2 bytes for pbft_prepared and pbft_my_prepare
-                 auto tmp_data_length = tmp_ds.tellp() - 6;
+                 block_header_state h;
+                 fc::raw::unpack( tmp_ds, h );
+                 signed_block_ptr b;
+                 fc::raw::unpack( tmp_ds, b );
+                 bool validated;
+                 fc::raw::unpack( tmp_ds, validated );
+                 bool in_current_chain;
+                 fc::raw::unpack( tmp_ds, in_current_chain );
+                 block_state s{h};
+                 s.block = b;
+                 s.validated = validated;
+                 s.in_current_chain = in_current_chain;
+                 //prepend 4bytes for pbft_stable_checkpoint_blocknum
+                 auto tmp_data_length = tmp_ds.tellp() - 4;
                  data.erase(data.begin(),data.begin()+tmp_data_length);
                  s.pbft_prepared = false;
                  s.pbft_my_prepare = false;

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -67,7 +67,7 @@ namespace eosio { namespace chain {
          bool is_version_1 = version_label != "version";
          if(is_version_1){
              /*start upgrade migration and this is a hack and ineffecient, but lucky we only need to do it once */
-
+             wlog("doing LIB upgrade migration");
              auto start = ds.pos();
              unsigned_int size; fc::raw::unpack( ds, size );
              auto skipped_size_pos = ds.pos();
@@ -75,6 +75,7 @@ namespace eosio { namespace chain {
              vector<char> data(content.begin()+(skipped_size_pos - start), content.end());
 
              for( uint32_t i = 0, n = size.value; i < n; ++i ) {
+                 wlog("processing block state in fork database ${i} of ${size}", ("i",i+1)("size",n));
                  vector<char> tmp = data;
                  tmp.insert(tmp.begin(), {0,0,0,0});
                  fc::datastream<const char*> tmp_ds(tmp.data(), tmp.size());

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -10,7 +10,6 @@ namespace eosio { namespace chain {
  *  @brief defines the minimum state necessary to validate transaction headers
  */
 struct block_header_state {
-    uint32_t                          pbft_stable_checkpoint_blocknum = 0;
     block_id_type                     id;
     uint32_t                          block_num = 0;
     signed_block_header               header;
@@ -28,6 +27,7 @@ struct block_header_state {
     public_key_type                   block_signing_key;
     vector<uint8_t>                   confirm_count;
     vector<header_confirmation>       confirmations;
+    uint32_t                          pbft_stable_checkpoint_blocknum = 0;
 
     block_header_state   next( const signed_block_header& h, bool trust = false, bool new_version = false)const;
     block_header_state   generate_next( block_timestamp_type when, bool new_version = false )const;
@@ -62,10 +62,10 @@ struct block_header_state {
 } } /// namespace eosio::chain
 
 FC_REFLECT( eosio::chain::block_header_state,
-            (pbft_stable_checkpoint_blocknum)
             (id)(block_num)(header)(dpos_proposed_irreversible_blocknum)(dpos_irreversible_blocknum)(bft_irreversible_blocknum)
 
             (pending_schedule_lib_num)(pending_schedule_hash)
             (pending_schedule)(active_schedule)(blockroot_merkle)
             (producer_to_last_produced)(producer_to_last_implied_irb)(block_signing_key)
-            (confirm_count)(confirmations) )
+            (confirm_count)(confirmations)
+            (pbft_stable_checkpoint_blocknum))

--- a/libraries/chain/include/eosio/chain/chain_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/chain_snapshot.hpp
@@ -33,7 +33,12 @@ struct batch_pbft_snapshot_migration{
   bool migrated = true;
 };
 
+struct batch_pbft_enabled {
+  bool enabled = true;
+};
+
 } }
 
 FC_REFLECT(eosio::chain::chain_snapshot_header,(version))
 FC_REFLECT(eosio::chain::batch_pbft_snapshot_migration,(migrated))
+FC_REFLECT(eosio::chain::batch_pbft_enabled,(enabled))

--- a/libraries/chain/include/eosio/chain/snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot.hpp
@@ -232,9 +232,9 @@ namespace eosio { namespace chain {
                      std::ostringstream sstream;
                      sstream << in.rdbuf();
                      std::string str(sstream.str());
-                     //prepend uint32_t 0
+                     //append uint32_t 0
                      std::vector<char> tmp(str.begin(), str.end());
-                     tmp.insert(tmp.begin(), {0,0,0,0});
+                     tmp.insert(tmp.end(), {0,0,0,0});
                      fc::datastream<const char*> tmp_ds(tmp.data(), tmp.size());
                      fc::raw::unpack(tmp_ds, data);
                      auto original_data_length = tmp_ds.tellp() - 4;

--- a/libraries/chain/pbft_database.cpp
+++ b/libraries/chain/pbft_database.cpp
@@ -1173,7 +1173,7 @@ namespace eosio {
                 const auto& ucb = ctrl.get_upgrade_properties().upgrade_complete_block_num;
                 if (!ctrl.is_pbft_enabled()) return false;
                 return in >= ucb
-                && (in % 100 == 1 || std::find(prepare_watermarks.begin(), prepare_watermarks.end(), in) != prepare_watermarks.end());
+                && (in == ucb + 1 || in % 100 == 1 || std::find(prepare_watermarks.begin(), prepare_watermarks.end(), in) != prepare_watermarks.end());
             };
 
             for (auto i = psp->block_num;

--- a/libraries/chain/pbft_database.cpp
+++ b/libraries/chain/pbft_database.cpp
@@ -1413,14 +1413,19 @@ namespace eosio {
         }
 
         producer_schedule_type pbft_database::lscb_active_producers() const {
-            auto lscb_num = ctrl.last_stable_checkpoint_block_num();
-            if (lscb_num == 0) return ctrl.initial_schedule();
+            auto num = ctrl.last_stable_checkpoint_block_num();
 
-            auto lscb_state = ctrl.fetch_block_state_by_number(lscb_num);
-            if (!lscb_state) return ctrl.initial_schedule();
+            if (num == 0) {
+                const auto &ucb = ctrl.get_upgrade_properties().upgrade_complete_block_num;
+                if (ucb == 0) return ctrl.initial_schedule();
+                num = ucb;
+            }
 
-            if (lscb_state->pending_schedule.producers.empty()) return lscb_state->active_schedule;
-            return lscb_state->pending_schedule;
+            auto bs = ctrl.fetch_block_state_by_number(num);
+            if (!bs) return ctrl.initial_schedule();
+
+            if (bs->pending_schedule.producers.empty()) return bs->active_schedule;
+            return bs->pending_schedule;
         }
 
         chain_id_type pbft_database::chain_id() {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1607,10 +1607,18 @@ void producer_plugin_impl::produce_block() {
    block_state_ptr new_bs = chain.head_block_state();
    _producer_watermarks[new_bs->header.producer] = chain.head_block_num();
 
-   ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} [trxs: ${count}, lib: ${lib}, lscb: ${lscb}]",
-        ("p",new_bs->header.producer)("id",fc::variant(new_bs->id).as_string().substr(0,16))
-        ("n",new_bs->block_num)("t",new_bs->header.timestamp)
-        ("count",new_bs->block->transactions.size())("lib",chain.last_irreversible_block_num())("lscb", chain.last_stable_checkpoint_block_num()));
+   if (chain.is_pbft_enabled()) {
+      ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} [trxs: ${count}, lib: ${lib}, lscb: ${lscb}]",
+           ("p", new_bs->header.producer)("id", fc::variant(new_bs->id).as_string().substr(0, 16))
+                   ("n", new_bs->block_num)("t", new_bs->header.timestamp)
+                   ("count", new_bs->block->transactions.size())
+                   ("lib", chain.last_irreversible_block_num())("lscb", chain.last_stable_checkpoint_block_num()));
+   } else {
+      ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} [trxs: ${count}, lib: ${lib}, confirmed: ${confs}]",
+           ("p",new_bs->header.producer)("id",fc::variant(new_bs->id).as_string().substr(0,16))
+                   ("n",new_bs->block_num)("t",new_bs->header.timestamp)
+                   ("count",new_bs->block->transactions.size())("lib",chain.last_irreversible_block_num())("confs", new_bs->header.confirmed));
+   }
 }
 
 } // namespace eosio


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description

bugfix:
1. fix crash bug caused by an existing bug
     fetch block by num 0 will cause crash when head num > 65535
2. fix incorrect pos align when doing fork db migration

added and improved features:
1. support snaptshot created by bos2.0.x before/after upgrade consensus protocol
1. improved fork db migration algorithm
1. use schedule in ucb when there is no stable checkpoint, this is added to bypass a bug when view change happens immediately after upgrade


