### PR TITLE
feature/dpos-pbft-bos-upgrade bugfix and snapshot support (#94)

### DIFF
--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -67,29 +67,43 @@ namespace eosio { namespace chain {
          bool is_version_1 = version_label != "version";
          if(is_version_1){
              /*start upgrade migration and this is a hack and ineffecient, but lucky we only need to do it once */
-
+             wlog("doing LIB upgrade migration");
              auto start = ds.pos();
              unsigned_int size; fc::raw::unpack( ds, size );
              auto skipped_size_pos = ds.pos();
 
              vector<char> data(content.begin()+(skipped_size_pos - start), content.end());
 
+             data.insert(data.end(),{0,0,0,0});//append 4 bytes for the very last block state, avoid underflow in case
+             fc::datastream<const char*> tmp_ds(data.data(), data.size());
+
              for( uint32_t i = 0, n = size.value; i < n; ++i ) {
-                 vector<char> tmp = data;
-                 tmp.insert(tmp.begin(), {0,0,0,0});
-                 fc::datastream<const char*> tmp_ds(tmp.data(), tmp.size());
-                 block_state s;
-                 fc::raw::unpack( tmp_ds, s );
-                 //prepend 4bytes for pbft_stable_checkpoint_blocknum and append 2 bytes for pbft_prepared and pbft_my_prepare
-                 auto tmp_data_length = tmp_ds.tellp() - 6;
-                 data.erase(data.begin(),data.begin()+tmp_data_length);
+                 wlog("processing block state in fork database ${i} of ${size}", ("i",i+1)("size",n));
+                 block_header_state h;
+                 fc::raw::unpack( tmp_ds, h );
+                 h.pbft_stable_checkpoint_blocknum = 0;
+
+                 //move pos backward 4 bytes for pbft_stable_checkpoint_blocknum
+                 auto tmp_accumulated_data_length = tmp_ds.tellp() - 4;
+                 tmp_ds.seekp(tmp_accumulated_data_length);
+
+                 signed_block_ptr b;
+                 fc::raw::unpack( tmp_ds, b );
+                 bool validated;
+                 fc::raw::unpack( tmp_ds, validated );
+                 bool in_current_chain;
+                 fc::raw::unpack( tmp_ds, in_current_chain );
+                 block_state s{h};
+                 s.block = b;
+                 s.validated = validated;
+                 s.in_current_chain = in_current_chain;
+
                  s.pbft_prepared = false;
                  s.pbft_my_prepare = false;
                  set( std::make_shared<block_state>( move( s ) ) );
              }
-             fc::datastream<const char*> head_id_stream(data.data(), data.size());
              block_id_type head_id;
-             fc::raw::unpack( head_id_stream, head_id );
+             fc::raw::unpack( tmp_ds, head_id );
 
              my->head = get_block( head_id );
              /*end upgrade migration*/

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -10,7 +10,6 @@ namespace eosio { namespace chain {
  *  @brief defines the minimum state necessary to validate transaction headers
  */
 struct block_header_state {
-    uint32_t                          pbft_stable_checkpoint_blocknum = 0;
     block_id_type                     id;
     uint32_t                          block_num = 0;
     signed_block_header               header;
@@ -28,6 +27,7 @@ struct block_header_state {
     public_key_type                   block_signing_key;
     vector<uint8_t>                   confirm_count;
     vector<header_confirmation>       confirmations;
+    uint32_t                          pbft_stable_checkpoint_blocknum = 0;
 
     block_header_state   next( const signed_block_header& h, bool trust = false, bool new_version = false)const;
     block_header_state   generate_next( block_timestamp_type when, bool new_version = false )const;
@@ -62,10 +62,10 @@ struct block_header_state {
 } } /// namespace eosio::chain
 
 FC_REFLECT( eosio::chain::block_header_state,
-            (pbft_stable_checkpoint_blocknum)
             (id)(block_num)(header)(dpos_proposed_irreversible_blocknum)(dpos_irreversible_blocknum)(bft_irreversible_blocknum)
 
             (pending_schedule_lib_num)(pending_schedule_hash)
             (pending_schedule)(active_schedule)(blockroot_merkle)
             (producer_to_last_produced)(producer_to_last_implied_irb)(block_signing_key)
-            (confirm_count)(confirmations) )
+            (confirm_count)(confirmations)
+            (pbft_stable_checkpoint_blocknum))

--- a/libraries/chain/include/eosio/chain/chain_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/chain_snapshot.hpp
@@ -33,7 +33,12 @@ struct batch_pbft_snapshot_migration{
   bool migrated = true;
 };
 
+struct batch_pbft_enabled {
+  bool enabled = true;
+};
+
 } }
 
 FC_REFLECT(eosio::chain::chain_snapshot_header,(version))
 FC_REFLECT(eosio::chain::batch_pbft_snapshot_migration,(migrated))
+FC_REFLECT(eosio::chain::batch_pbft_enabled,(enabled))

--- a/libraries/chain/include/eosio/chain/snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/snapshot.hpp
@@ -232,9 +232,9 @@ namespace eosio { namespace chain {
                      std::ostringstream sstream;
                      sstream << in.rdbuf();
                      std::string str(sstream.str());
-                     //prepend uint32_t 0
+                     //append uint32_t 0
                      std::vector<char> tmp(str.begin(), str.end());
-                     tmp.insert(tmp.begin(), {0,0,0,0});
+                     tmp.insert(tmp.end(), {0,0,0,0});
                      fc::datastream<const char*> tmp_ds(tmp.data(), tmp.size());
                      fc::raw::unpack(tmp_ds, data);
                      auto original_data_length = tmp_ds.tellp() - 4;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1607,10 +1607,18 @@ void producer_plugin_impl::produce_block() {
    block_state_ptr new_bs = chain.head_block_state();
    _producer_watermarks[new_bs->header.producer] = chain.head_block_num();
 
-   ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} [trxs: ${count}, lib: ${lib}, lscb: ${lscb}]",
-        ("p",new_bs->header.producer)("id",fc::variant(new_bs->id).as_string().substr(0,16))
-        ("n",new_bs->block_num)("t",new_bs->header.timestamp)
-        ("count",new_bs->block->transactions.size())("lib",chain.last_irreversible_block_num())("lscb", chain.last_stable_checkpoint_block_num()));
+   if (chain.is_pbft_enabled()) {
+      ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} [trxs: ${count}, lib: ${lib}, lscb: ${lscb}]",
+           ("p", new_bs->header.producer)("id", fc::variant(new_bs->id).as_string().substr(0, 16))
+                   ("n", new_bs->block_num)("t", new_bs->header.timestamp)
+                   ("count", new_bs->block->transactions.size())
+                   ("lib", chain.last_irreversible_block_num())("lscb", chain.last_stable_checkpoint_block_num()));
+   } else {
+      ilog("Produced block ${id}... #${n} @ ${t} signed by ${p} [trxs: ${count}, lib: ${lib}, confirmed: ${confs}]",
+           ("p",new_bs->header.producer)("id",fc::variant(new_bs->id).as_string().substr(0,16))
+                   ("n",new_bs->block_num)("t",new_bs->header.timestamp)
+                   ("count",new_bs->block->transactions.size())("lib",chain.last_irreversible_block_num())("confs", new_bs->header.confirmed));
+   }
 }
 
 } // namespace eosio


### PR DESCRIPTION
* bugfix: fork_db migration incorrect pos align

* bug fix: return default block id when trying to fetch block num 0; update pbft status during ctrl init.

* add migration log

* improve: change algorithm in LIB upgrade fork database migration, huge performance boost when fork db size is large

* use schedule in ucb when there is no stable checkpoint.

* update snapshot migration logic to reflect struct change in block header state

* add forkdb block states into snapshot after pbft is enabled; fix replay bug.

* change block producing log