### PR TITLE
fix: pbft new view generation

### DIFF
--- a/libraries/chain/include/eosio/chain/pbft_database.hpp
+++ b/libraries/chain/include/eosio/chain/pbft_database.hpp
@@ -519,6 +519,7 @@ namespace eosio {
             vector<block_num_type> get_pbft_watermarks() const;
             flat_map<public_key_type, uint32_t> get_pbft_fork_schedules() const;
 
+            producer_schedule_type lscb_active_producers() const;
         private:
             controller&                                 ctrl;
             pbft_state_multi_index_type                 pbft_state_index;
@@ -537,7 +538,6 @@ namespace eosio {
             bool is_valid_committed_certificate(const pbft_committed_certificate& certificate, bool add_to_pbft_db = false, bool at_the_top = false);
             bool is_valid_longest_fork(const vector<producer_and_block_info>& producers, const block_info_type& cert_info, bool at_the_top = false);
 
-            producer_schedule_type lscb_active_producers() const;
             vector<block_num_type>& get_updated_watermarks();
             flat_map<public_key_type, uint32_t>& get_updated_fork_schedules();
             block_num_type get_current_pbft_watermark();

--- a/plugins/pbft_api_plugin/README.md
+++ b/plugins/pbft_api_plugin/README.md
@@ -85,3 +85,24 @@
     ```
     curl --request POST --data uint32_t --url http://localhost:8888/v1/pbft/set_pbft_current_view  
     ```
+* **get_view_change_missing_bps**
+
+    -- To get missing bp names of a given pbft view on my node, empty will be returned if all have been collected or not in view change state    
+    
+    ```
+    curl --request POST --data uint32_t --url http://localhost:8888/v1/pbft/get_view_change_missing_bps  
+    ```
+* **get_prepare_missing_bps**
+
+    -- To get missing bp names of prepare messages of a given block id at the highest view on my node, empty will be returned if all have been collected or the block id is unreachable    
+    
+    ```
+    curl --request POST --data string --url http://localhost:8888/v1/pbft/get_prepare_missing_bps  
+    ```      
+* **get_commit_missing_bps**
+
+    -- To get missing bp names of commit messages of a given block id at the highest view on my node, empty will be returned if all have been collected or the block id is unreachable    
+    
+    ```
+    curl --request POST --data string --url http://localhost:8888/v1/pbft/get_commit_missing_bps  
+    ```

--- a/plugins/pbft_api_plugin/pbft_api_plugin.cpp
+++ b/plugins/pbft_api_plugin/pbft_api_plugin.cpp
@@ -59,6 +59,9 @@ void pbft_api_plugin::plugin_startup() {
        CALL(pbft, pbft, get_pbft_status, INVOKE_R(pbft, get_pbft_status), 200),
        CALL(pbft, pbft, get_pbft_prepared_id, INVOKE_R(pbft, get_pbft_prepared_id), 200),
        CALL(pbft, pbft, get_pbft_my_prepare_id, INVOKE_R(pbft, get_pbft_my_prepare_id), 200),
+       CALL(pbft, pbft, get_view_change_missing_bps, INVOKE_R_P(pbft, get_view_change_missing_bps, pbft_view_type), 200),
+       CALL(pbft, pbft, get_prepare_missing_bps, INVOKE_R_P(pbft, get_prepare_missing_bps, block_id_type), 200),
+       CALL(pbft, pbft, get_commit_missing_bps, INVOKE_R_P(pbft, get_commit_missing_bps, block_id_type), 200),
        CALL(pbft, pbft, set_pbft_current_view, INVOKE_W_P(pbft, set_pbft_current_view, pbft_view_type), 201),
    });
 }

--- a/plugins/pbft_plugin/include/eosio/pbft_plugin/pbft_plugin.hpp
+++ b/plugins/pbft_plugin/include/eosio/pbft_plugin/pbft_plugin.hpp
@@ -7,6 +7,7 @@
 #include <eosio/chain/pbft.hpp>
 #include <eosio/chain_plugin/chain_plugin.hpp>
 #include <eosio/net_plugin/net_plugin.hpp>
+#include <eosio/producer_plugin/producer_plugin.hpp>
 
 namespace eosio {
 
@@ -33,12 +34,15 @@ public:
    const char* get_pbft_status()const;
    block_id_type get_pbft_prepared_id()const;
    block_id_type get_pbft_my_prepare_id()const;
-
+   vector<producer_key> get_view_change_missing_bps(pbft_view_type view)const;
+   vector<producer_key> get_prepare_missing_bps(const block_id_type& bid)const;
+   vector<producer_key> get_commit_missing_bps(const block_id_type& bid)const;
    void set_pbft_current_view(pbft_view_type view);
 
 
 private:
    std::unique_ptr<class pbft_plugin_impl> my;
+   chain_plugin*                           chain_plug = nullptr;
 };
 
 }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
Bug fixes:
1. Varify certifications before generating new view 
2. Shuffle view change messages during new view generation
3. Check if production is paused in `pbft_ready()`  

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
Add `get_view_change_missing_bps`, `get_prepare_missing_bps`, `get_commit_missing_bps` in `pbft_api_plugin`, helping to identify missing bp messages. Refer to [README](https://github.com/boscore/bos/blob/6f91e2cf29f2a0071e481e79837d67dabac7efc6/plugins/pbft_api_plugin/README.md) for more infomation.

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

<!-- List all the information that needs to be added to the documentation after merge. -->
