### PR TITLE
Add: account query database

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -35,6 +35,23 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
    }
 };
 
+namespace {
+   template<typename T>
+   T parse_params(const std::string& body) {
+      if (body.empty()) {
+         EOS_THROW(chain::invalid_http_request, "A Request body is required");
+      }
+
+      try {
+        try {
+           return fc::json::from_string(body).as<T>();
+        } catch (const chain::chain_exception& e) { // EOS_RETHROW_EXCEPTIONS does not re-type these so, re-code it
+          throw fc::exception(e);
+        }
+      } EOS_RETHROW_EXCEPTIONS(chain::invalid_http_request, "Unable to parse valid input from POST body");
+   }
+}
+
 #define CALL(api_name, api_handle, api_namespace, call_name, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
    [api_handle](string, string body, url_response_callback cb) mutable { \
@@ -42,6 +59,19 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
           try { \
              if (body.empty()) body = "{}"; \
              fc::variant result( api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()) ); \
+             cb(http_response_code, std::move(result)); \
+          } catch (...) { \
+             http_plugin::handle_exception(#api_name, #call_name, body, cb); \
+          } \
+       }}
+
+#define CALL_WITH_400(api_name, api_handle, api_namespace, call_name, http_response_code) \
+{std::string("/v1/" #api_name "/" #call_name), \
+   [api_handle](string, string body, url_response_callback cb) mutable { \
+          api_handle.validate(); \
+          try { \
+             auto params = parse_params<api_namespace::call_name ## _params>(body);\
+             fc::variant result( api_handle.call_name( std::move(params) ) ); \
              cb(http_response_code, std::move(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
@@ -73,11 +103,14 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
 #define CHAIN_RO_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, ro_api, chain_apis::read_only, call_name, call_result, http_response_code)
 #define CHAIN_RW_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, rw_api, chain_apis::read_write, call_name, call_result, http_response_code)
 
+#define CHAIN_RO_CALL_WITH_400(call_name, http_response_code) CALL_WITH_400(chain, ro_api, chain_apis::read_only, call_name, http_response_code)
+
 void chain_api_plugin::plugin_startup() {
    ilog( "starting chain_api_plugin" );
    my.reset(new chain_api_plugin_impl(app().get_plugin<chain_plugin>().chain()));
-   auto ro_api = app().get_plugin<chain_plugin>().get_read_only_api();
-   auto rw_api = app().get_plugin<chain_plugin>().get_read_write_api();
+   auto& chain = app().get_plugin<chain_plugin>();
+   auto ro_api = chain.get_read_only_api();
+   auto rw_api = chain.get_read_write_api();
 
    auto& _http_plugin = app().get_plugin<http_plugin>();
    ro_api.set_shorten_abi_errors( !_http_plugin.verbose_errors() );
@@ -107,6 +140,12 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202)
    });
+
+   if (chain.account_queries_enabled()) {
+      _http_plugin.add_async_api({
+         CHAIN_RO_CALL_WITH_400(get_accounts_by_authorizers, 200),
+      });
+   }
 }
 
 void chain_api_plugin::plugin_shutdown() {}

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(GLOB HEADERS "include/eosio/chain_plugin/*.hpp")
 add_library( chain_plugin
+             account_query_db.cpp
              chain_plugin.cpp
              ${HEADERS} )
 

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -1,0 +1,479 @@
+#include <eosio/chain_plugin/account_query_db.hpp>
+
+#include <eosio/chain/contract_types.hpp>
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/permission_object.hpp>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/multi_index/member.hpp>
+
+#include <boost/bimap.hpp>
+#include <boost/bimap/multiset_of.hpp>
+#include <boost/bimap/set_of.hpp>
+
+#include <shared_mutex>
+
+using namespace eosio;
+using namespace boost::multi_index;
+using namespace boost::bimaps;
+
+namespace {
+   /**
+    * Structure to hold indirect reference to a `property_object` via {owner,name} as well as a non-standard
+    * index over `last_updated` for roll-back support
+    */
+   struct permission_info {
+      // indexed data
+      chain::name    owner;
+      chain::name    name;
+      fc::time_point last_updated;
+
+      // un-indexed data
+      uint32_t       threshold;
+
+      using cref = std::reference_wrapper<const permission_info>;
+   };
+
+   struct by_owner_name;
+   struct by_last_updated;
+
+   /**
+    * Multi-index providing fast lookup for {owner,name} as well as {last_updated}
+    */
+   using permission_info_index_t = multi_index_container<
+      permission_info,
+      indexed_by<
+         ordered_unique<
+            tag<by_owner_name>,
+            composite_key<permission_info,
+               member<permission_info, chain::name, &permission_info::owner>,
+               member<permission_info, chain::name, &permission_info::name>
+            >
+         >,
+         ordered_non_unique<
+            tag<by_last_updated>,
+            member<permission_info, fc::time_point, &permission_info::last_updated>
+         >
+      >
+   >;
+
+   /**
+    * Utility function to identify on-block action
+    * @param p
+    * @return
+    */
+   bool is_onblock(const chain::transaction_trace_ptr& p) {
+      if (p->action_traces.empty())
+         return false;
+      const auto& act = p->action_traces[0].act;
+      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
+          act.authorization.size() != 1)
+         return false;
+      const auto& auth = act.authorization[0];
+      return auth.actor == eosio::chain::config::system_account_name &&
+             auth.permission == eosio::chain::config::active_name;
+   }
+
+   template<typename T>
+   struct weighted {
+      T                   value;
+      chain::weight_type  weight;
+
+      static weighted lower_bound_for( const T& value ) {
+         return {value, std::numeric_limits<chain::weight_type>::min()};
+      }
+
+      static weighted upper_bound_for( const T& value ) {
+         return {value, std::numeric_limits<chain::weight_type>::max()};
+      }
+   };
+
+   template<typename Output, typename Input>
+   auto make_optional_authorizer(const Input& authorizer) -> fc::optional<Output> {
+      if constexpr (std::is_same_v<Input, Output>) {
+         return authorizer;
+      } else {
+         return {};
+      }
+   }
+}
+
+namespace std {
+   /**
+    * support for using `permission_info::cref` in ordered containers
+    */
+   template<>
+   struct less<permission_info::cref> {
+      bool operator()( const permission_info::cref& lhs, const permission_info::cref& rhs ) const {
+         return std::uintptr_t(&lhs.get()) < std::uintptr_t(&rhs.get());
+      }
+   };
+
+   /**
+    * support for using `weighted<T>` in ordered containers
+    */
+   template<typename T>
+   struct less<weighted<T>> {
+      bool operator()( const weighted<T>& lhs, const weighted<T>& rhs ) const {
+         return std::tie(lhs.value, lhs.weight) < std::tie(rhs.value, rhs.weight);
+      }
+   };
+
+}
+
+namespace eosio::chain_apis {
+   /**
+    * Implementation details of the account query DB
+    */
+   struct account_query_db_impl {
+      account_query_db_impl(const chain::controller& controller)
+      :controller(controller)
+      {}
+
+      /**
+       * Build the initial database from the chain controller by extracting the information contained in the
+       * blockchain state at the current HEAD
+       */
+      void build_account_query_map() {
+         std::unique_lock write_lock(rw_mutex);
+
+         ilog("Building account query DB");
+         auto start = fc::time_point::now();
+         const auto& index = controller.db().get_index<chain::permission_index>().indices().get<by_id>();
+
+         for (const auto& po : index ) {
+            const auto& pi = permission_info_index.emplace( permission_info{ po.owner, po.name, po.last_updated, po.auth.threshold } ).first;
+            add_to_bimaps(*pi, po);
+         }
+         auto duration = fc::time_point::now() - start;
+         ilog("Finished building account query DB in ${sec}", ("sec", (duration.count() / 1'000'000.0 )));
+      }
+
+      /**
+       * Add a permission to the bimaps for keys and accounts
+       * @param pi - the ephemeral permission info structure being added
+       * @param po - the chain data associted with this permission
+       */
+      void add_to_bimaps( const permission_info& pi, const chain::permission_object& po ) {
+         // For each account, add this permission info's non-owning reference to the bimap for accounts
+         for (const auto& a : po.auth.accounts) {
+            name_bimap.insert(name_bimap_t::value_type {{a.permission, a.weight}, pi});
+         }
+
+         // for each key, add this permission info's non-owning reference to the bimap for keys
+         for (const auto& k: po.auth.keys) {
+            chain::public_key_type key = k.key;
+            key_bimap.insert(key_bimap_t::value_type {{std::move(key), k.weight}, pi});
+         }
+      }
+
+      /**
+       * Remove a permission from the bimaps for keys and accounts
+       * @param pi - the ephemeral permission info structure being removed
+       */
+      void remove_from_bimaps( const permission_info& pi ) {
+         // remove all entries from the name bimap that refer to this permission_info's reference
+         const auto name_range = name_bimap.right.equal_range(pi);
+         name_bimap.right.erase(name_range.first, name_range.second);
+
+         // remove all entries from the key bimap that refer to this permission_info's reference
+         const auto key_range = key_bimap.right.equal_range(pi);
+         key_bimap.right.erase(key_range.first, key_range.second);
+      }
+
+      bool is_rollback_required( const chain::block_state_ptr& bsp ) const {
+         std::shared_lock read_lock(rw_mutex);
+         const auto t = bsp->block->timestamp.to_time_point();
+         const auto& index = permission_info_index.get<by_last_updated>();
+
+         if (index.empty()) {
+            return false;
+         } else {
+            const auto& pi = (*index.rbegin());
+            if (pi.last_updated < t) {
+               return false;
+            }
+         }
+
+         return true;
+      }
+
+      /**
+       * Given a time_point, remove all permissions that were last updated at or after that time_point
+       * this will effectively remove any updates that happened at or after that time point
+       *
+       * For each removed entry, this will create a new entry if there exists an equivalent {owner, name} permission
+       * at the HEAD state of the chain.
+       * @param bsp - the block to rollback before
+       */
+      void rollback_to_before( const chain::block_state_ptr& bsp ) {
+         const auto t = bsp->block->timestamp.to_time_point();
+         auto& index = permission_info_index.get<by_last_updated>();
+         const auto& permission_by_owner = controller.db().get_index<chain::permission_index>().indices().get<chain::by_owner>();
+
+         while (!index.empty()) {
+            const auto& pi = (*index.rbegin());
+            if (pi.last_updated < t) {
+               break;
+            }
+
+            // remove this entry from the bimaps
+            remove_from_bimaps(pi);
+
+            auto itr = permission_by_owner.find(std::make_tuple(pi.owner, pi.name));
+            if (itr == permission_by_owner.end()) {
+               // this permission does not exist at this point in the chains history
+               index.erase(index.iterator_to(pi));
+            } else {
+               const auto& po = *itr;
+               index.modify(index.iterator_to(pi), [&po](auto& mutable_pi) {
+                  mutable_pi.last_updated = po.last_updated;
+                  mutable_pi.threshold = po.auth.threshold;
+               });
+               add_to_bimaps(pi, po);
+            }
+         }
+      }
+
+      /**
+       * Store a potentially relevant transaction trace in a short lived cache so that it can be processed if its
+       * committed to by a block
+       * @param trace
+       */
+      void cache_transaction_trace( const chain::transaction_trace_ptr& trace ) {
+         if( !trace->receipt ) return;
+         // include only executed transactions; soft_fail included so that onerror (and any inlines via onerror) are included
+         if((trace->receipt->status != chain::transaction_receipt_header::executed &&
+             trace->receipt->status != chain::transaction_receipt_header::soft_fail)) {
+            return;
+         }
+         if( is_onblock( trace )) {
+            onblock_trace.emplace( trace );
+         } else if( trace->failed_dtrx_trace ) {
+            cached_trace_map[trace->failed_dtrx_trace->id] = trace;
+         } else {
+            cached_trace_map[trace->id] = trace;
+         }
+      }
+
+      using permission_set_t = std::set<chain::permission_level>;
+      /**
+       * Pre-Commit step with const qualifier to guarantee it does not mutate
+       * the thread-safe data set
+       * @param bsp
+       */
+      auto commit_block_prelock( const chain::block_state_ptr& bsp ) const {
+         permission_set_t updated;
+         permission_set_t deleted;
+
+         /**
+          * process traces to find `updateauth` and `deleteauth` calls maintaining a final set of
+          * permissions to either update or delete.  Intra-block changes are discarded
+          */
+         auto process_trace = [&](const chain::transaction_trace_ptr& trace) {
+            for( const auto& at : trace->action_traces ) {
+               if (std::tie(at.receiver, at.act.account) != std::tie(chain::config::system_account_name,chain::config::system_account_name)) {
+                  continue;
+               }
+
+               if (at.act.name == chain::updateauth::get_name()) {
+                  auto data = at.act.data_as<chain::updateauth>();
+                  auto itr = updated.emplace(chain::permission_level{data.account, data.permission}).first;
+                  deleted.erase(*itr);
+               } else if (at.act.name == chain::deleteauth::get_name()) {
+                  auto data = at.act.data_as<chain::deleteauth>();
+                  auto itr = deleted.emplace(chain::permission_level{data.account, data.permission}).first;
+                  updated.erase(*itr);
+               }
+            }
+         };
+
+         if( onblock_trace )
+            process_trace(*onblock_trace);
+
+         for( const auto& r : bsp->block->transactions ) {
+            chain::transaction_id_type id;
+            if( r.trx.contains<chain::transaction_id_type>()) {
+               id = r.trx.get<chain::transaction_id_type>();
+            } else {
+               id = r.trx.get<chain::packed_transaction>().id();
+            }
+
+            const auto it = cached_trace_map.find( id );
+            if( it != cached_trace_map.end() ) {
+               process_trace( it->second );
+            }
+         }
+
+         return std::make_tuple(std::move(updated), std::move(deleted), is_rollback_required(bsp));
+      }
+
+      /**
+       * Commit a block of transactions to the account query DB
+       * transaction traces need to be in the cache prior to this call
+       * @param bsp
+       */
+      void commit_block(const chain::block_state_ptr& bsp ) {
+         permission_set_t updated;
+         permission_set_t deleted;
+         bool rollback_required = false;
+
+         std::tie(updated, deleted, rollback_required) = commit_block_prelock(bsp);
+
+         // optimistic skip of locking section if there is nothing to do
+         if (!updated.empty() || !deleted.empty() || rollback_required) {
+            std::unique_lock write_lock(rw_mutex);
+
+            rollback_to_before(bsp);
+            auto& index = permission_info_index.get<by_owner_name>();
+            const auto& permission_by_owner = controller.db().get_index<chain::permission_index>().indices().get<chain::by_owner>();
+
+            // for each updated permission, find the new values and update the account query db
+            for (const auto& up: updated) {
+               auto key = std::make_tuple(up.actor, up.permission);
+               auto source_itr = permission_by_owner.find(key);
+               EOS_ASSERT(source_itr != permission_by_owner.end(), chain::plugin_exception, "chain data is missing");
+               auto itr = index.find(key);
+               if (itr == index.end()) {
+                  const auto& po = *source_itr;
+                  itr = index.emplace(permission_info{ po.owner, po.name, po.last_updated, po.auth.threshold }).first;
+               } else {
+                  remove_from_bimaps(*itr);
+                  index.modify(itr, [&](auto& mutable_pi){
+                     mutable_pi.last_updated = source_itr->last_updated;
+                     mutable_pi.threshold = source_itr->auth.threshold;
+                  });
+               }
+
+               add_to_bimaps(*itr, *source_itr);
+            }
+
+            // for all deleted permissions, process their removal from the account query DB
+            for (const auto& dp: deleted) {
+               auto key = std::make_tuple(dp.actor, dp.permission);
+               auto itr = index.find(key);
+               if (itr != index.end()) {
+                  remove_from_bimaps(*itr);
+                  index.erase(itr);
+               }
+            }
+         }
+
+         // drop any unprocessed cached traces
+         cached_trace_map.clear();
+         onblock_trace.reset();
+      }
+
+      account_query_db::get_accounts_by_authorizers_result
+      get_accounts_by_authorizers( const account_query_db::get_accounts_by_authorizers_params& args) const {
+         std::shared_lock read_lock(rw_mutex);
+
+         using result_t = account_query_db::get_accounts_by_authorizers_result;
+         result_t result;
+
+         // deduplicate inputs
+         auto account_set = std::set<chain::permission_level>(args.accounts.begin(), args.accounts.end());
+         const auto key_set = std::set<chain::public_key_type>(args.keys.begin(), args.keys.end());
+
+         /**
+          * Add a range of results
+          */
+         auto push_results = [&result](const auto& begin, const auto& end) {
+            for (auto itr = begin; itr != end; ++itr) {
+               const auto& pi = itr->second.get();
+               const auto& authorizer = itr->first.value;
+               auto weight = itr->first.weight;
+
+               result.accounts.emplace_back(result_t::account_result{
+                     pi.owner,
+                     pi.name,
+                     make_optional_authorizer<chain::permission_level>(authorizer),
+                     make_optional_authorizer<chain::public_key_type>(authorizer),
+                     weight,
+                     pi.threshold
+               });
+            }
+         };
+
+
+         for (const auto& a: account_set) {
+            if (a.permission.empty()) {
+               // empty permission is a wildcard
+               // construct a range between the lower bound of the given account and the lower bound of the
+               // next possible account name
+               const auto begin = name_bimap.left.lower_bound(weighted<chain::permission_level>::lower_bound_for({a.actor, a.permission}));
+               const auto next_account_name = chain::name(a.actor.to_uint64_t() + 1);
+               const auto end = name_bimap.left.lower_bound(weighted<chain::permission_level>::lower_bound_for({next_account_name, a.permission}));
+               push_results(begin, end);
+            } else {
+               // construct a range of all possible weights for an account/permission pair
+               const auto p = chain::permission_level{a.actor, a.permission};
+               const auto begin = name_bimap.left.lower_bound(weighted<chain::permission_level>::lower_bound_for(p));
+               const auto end = name_bimap.left.upper_bound(weighted<chain::permission_level>::upper_bound_for(p));
+               push_results(begin, end);
+            }
+         }
+
+         for (const auto& k: key_set) {
+            // construct a range of all possible weights for a key
+            const auto begin = key_bimap.left.lower_bound(weighted<chain::public_key_type>::lower_bound_for(k));
+            const auto end = key_bimap.left.upper_bound(weighted<chain::public_key_type>::upper_bound_for(k));
+            push_results(begin, end);
+         }
+
+         return result;
+      }
+
+      /**
+       * Convenience aliases
+       */
+      using cached_trace_map_t = std::map<chain::transaction_id_type, chain::transaction_trace_ptr>;
+      using onblock_trace_t = std::optional<chain::transaction_trace_ptr>;
+
+      const chain::controller&   controller;               ///< the controller to read data from
+      cached_trace_map_t         cached_trace_map;         ///< temporary cache of uncommitted traces
+      onblock_trace_t            onblock_trace;            ///< temporary cache of on_block trace
+
+
+      using name_bimap_t = bimap<multiset_of<weighted<chain::permission_level>>, multiset_of<permission_info::cref>>;
+      using key_bimap_t = bimap<multiset_of<weighted<chain::public_key_type>>, multiset_of<permission_info::cref>>;
+
+      /*
+       * The structures below are shared between the writing thread and the reading thread(s) and must be protected
+       * by the `rw_mutex`
+       */
+      permission_info_index_t    permission_info_index;    ///< multi-index that holds ephemeral indices
+      name_bimap_t               name_bimap;               ///< many:many bimap of names:permission_infos
+      key_bimap_t                key_bimap;                ///< many:many bimap of keys:permission_infos
+
+      mutable std::shared_mutex  rw_mutex;                 ///< mutex for read/write locking on the Multi-index and bimaps
+   };
+
+   account_query_db::account_query_db( const chain::controller& controller )
+   :_impl(std::make_unique<account_query_db_impl>(controller))
+   {
+      _impl->build_account_query_map();
+   }
+
+   account_query_db::~account_query_db() = default;
+   account_query_db & account_query_db::operator=(account_query_db &&) = default;
+
+   void account_query_db::cache_transaction_trace( const chain::transaction_trace_ptr& trace ) {
+      try {
+         _impl->cache_transaction_trace(trace);
+      } FC_LOG_AND_DROP(("ACCOUNT DB cache_transaction_trace ERROR"));
+   }
+
+   void account_query_db::commit_block(const chain::block_state_ptr& block ) {
+      try {
+         _impl->commit_block(block);
+      } FC_LOG_AND_DROP(("ACCOUNT DB commit_block ERROR"));
+   }
+
+   account_query_db::get_accounts_by_authorizers_result account_query_db::get_accounts_by_authorizers( const account_query_db::get_accounts_by_authorizers_params& args) const {
+      return _impl->get_accounts_by_authorizers(args);
+   }
+
+}

--- a/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/account_query_db.hpp
@@ -1,0 +1,136 @@
+#pragma once
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/block_state.hpp>
+#include <eosio/chain/trace.hpp>
+
+namespace eosio::chain_apis {
+   /**
+    * This class manages the ephemeral indices and data that provide the `get_accounts_by_authorizers` RPC call
+    * There is no persistence and the indices/caches are recreated when the class is instantiated based on the
+    * current state of the chain.
+    */
+   class account_query_db {
+   public:
+
+      /**
+       * Instantiate a new account query DB from the given chain controller
+       * The caller is expected to manage lifetimes such that this controller reference does not go stale
+       * for the life of the account query DB
+       * @param chain - controller to read data from
+       */
+      account_query_db( const class eosio::chain::controller& chain );
+      ~account_query_db();
+
+      /**
+       * Allow moving the account query DB (including by assignment)
+       */
+      account_query_db(account_query_db&&);
+      account_query_db& operator=(account_query_db&&);
+
+      /**
+       * Add a transaction trace to the account query DB that has been applied to the contoller even though it may
+       * not yet be committed to by a block.
+       *
+       * @param trace
+       */
+      void cache_transaction_trace( const chain::transaction_trace_ptr& trace );
+
+      /**
+       * Add a block to the account query DB, committing all the cached traces it represents and dumping any
+       * uncommitted traces.
+       * @param block
+       */
+      void commit_block(const chain::block_state_ptr& block );
+
+      /**
+       * parameters for the get_accounts_by_authorizers RPC
+       */
+      struct get_accounts_by_authorizers_params{
+         /**
+          * This structure is an concrete alias of `chain::permission_level` to facilitate
+          * specialized rules when transforming to/from variants.
+          */
+         struct permission_level : public chain::permission_level {
+         };
+
+         std::vector<permission_level> accounts;
+         std::vector<chain::public_key_type> keys;
+      };
+
+      /**
+       * Result of the get_accounts_by_authorizers RPC
+       */
+      struct get_accounts_by_authorizers_result{
+         struct account_result {
+            chain::name                            account_name;
+            chain::name                            permission_name;
+            fc::optional<chain::permission_level>  authorizing_account;
+            fc::optional<chain::public_key_type>   authorizing_key;
+            chain::weight_type                     weight;
+            uint32_t                               threshold;
+         };
+
+         std::vector<account_result> accounts;
+      };
+      /**
+       * Given a set of account names and public keys, find all account permission authorities that are, in part or whole,
+       * satisfiable.
+       *
+       * @param args
+       * @return
+       */
+      get_accounts_by_authorizers_result get_accounts_by_authorizers( const get_accounts_by_authorizers_params& args) const;
+
+   private:
+      std::unique_ptr<struct account_query_db_impl> _impl;
+   };
+
+}
+
+namespace fc {
+   using params = eosio::chain_apis::account_query_db::get_accounts_by_authorizers_params;
+   /**
+    * Overloaded to_variant so that permission is only present if it is set
+    * @param a
+    * @param v
+    */
+   inline void to_variant(const params::permission_level& a, fc::variant& v) {
+      if (a.permission.empty()) {
+         v = a.actor.to_string();
+      } else {
+         v = mutable_variant_object()
+            ("actor", a.actor.to_string())
+            ("permission", a.permission.to_string());
+      }
+   }
+
+   /**
+    * Overloaded from_variant to allow parsing an account with a permission wildcard (empty) from a string
+    * instead of an object
+    * @param v
+    * @param a
+    */
+   inline void from_variant(const fc::variant& v, params::permission_level& a) {
+      if (v.is_string()) {
+         from_variant(v, a.actor);
+         a.permission = {};
+      } else if (v.is_object()) {
+         const auto& vo = v.get_object();
+         if(vo.contains("actor"))
+            from_variant(vo["actor"], a.actor);
+         else
+            EOS_THROW(eosio::chain::invalid_http_request, "Missing Actor field");
+
+         if(vo.contains("permission") && vo.size() == 2)
+            from_variant(vo["permission"], a.permission);
+         else if (vo.size() == 1)
+            a.permission = {};
+         else
+            EOS_THROW(eosio::chain::invalid_http_request, "Unrecognized fields in account");
+      }
+   }
+}
+
+FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_params, (accounts)(keys))
+FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_result::account_result, (account_name)(permission_name)(authorizing_account)(authorizing_key)(weight)(threshold))
+FC_REFLECT( eosio::chain_apis::account_query_db::get_accounts_by_authorizers_result, (accounts))

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -86,6 +86,11 @@ namespace eosio {
               add_handler(call.first, call.second);
         }
 
+       void add_async_api(const api_description& api) {
+           for (const auto& call : api)
+               add_handler(call.first, call.second);
+       }
+
         // standard exception handling for api handlers
         static void handle_exception( const char *api_name, const char *call_name, const string& body, url_response_callback cb );
 

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);
    chain_apis::read_only::get_block_params param{headnumstr};
-   chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX), *(this->pbft_ctrl));
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds(INT_MAX), *(this->pbft_ctrl));
 
    // block should be decoded successfully
    std::string block_str = json::to_pretty_string(plugin.get_block(param));

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    produce_blocks(1);
 
    // iterate over scope
-   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX), *(this->pbft_ctrl));
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds(INT_MAX), *(this->pbft_ctrl));
    eosio::chain_apis::read_only::get_table_by_scope_params param{N(eosio.token), N(accounts), "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param);
 
@@ -194,7 +194,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX), *(this->pbft_ctrl));
+   eosio::chain_apis::read_only plugin(*(this->control), {} fc::microseconds(INT_MAX), *(this->pbft_ctrl));
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = N(eosio.token);
    p.scope = "inita";
@@ -363,7 +363,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX), *(this->pbft_ctrl));
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds(INT_MAX), *(this->pbft_ctrl));
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = N(eosio);
    p.scope = "eosio";


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- Give your PR a title that is sufficient to understand what is being changed. -->

## Change Description
Add account query db, link to EOSIO [feature](https://github.com/EOSIO/eos/pull/8899). resolve: #159 

<!-- Describe the change you made, the motivation for it, and the impact it will have. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

## Consensus Changes

<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes

```bash
$ curl http://127.0.0.1:8888/v1/chain/get_accounts_by_authorizers -d '{"keys":["EOS..."]}' 2>/dev/null | jq '[.accounts[].account_name] | unique'
```

```bash
$ curl http://127.0.0.1:8888/v1/chain/get_accounts_by_authorizers -d '{"accounts":["alice"]}' 2>/dev/null | jq '[.accounts[].account_name] | unique'
```

<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions

## --enable-account-queries
*default: false*

Boolean that indicates whether the Account Query DB should be initialized at start-up and maintained for the life of this instance. if set to true then the RPC endpoint for `/v1/chain/get_accounts_by_authorizers` will be registered otherwise it will not be present and requests to that endpoint will return `404` errors.
